### PR TITLE
Fix redis connection issues

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -20,6 +20,8 @@ healthcheckTimeout = 300
 [services.variables]
 NODE_ENV = "production"
 PORT = "3001"
+# Use Railway public proxy for Redis to avoid internal DNS resolution issues
+REDIS_URL = "redis://default:uSJmhvtfgYyWUMrFrSGrcuUAVXQfkpvD@metro.proxy.rlwy.net:54279"
 # IMPORTANT: Set these environment variables in Railway Dashboard:
 # DISCORD_TOKEN = "your_discord_bot_token"
 # DISCORD_CLIENT_ID = "your_discord_client_id"
@@ -50,6 +52,8 @@ healthcheckTimeout = 300
 NODE_ENV = "production"
 PORT = "3000"
 BOT_API_BASE_URL = "https://ticketmesh-bot-production.up.railway.app"
+# Use Railway public proxy for Redis to avoid internal DNS resolution issues
+REDIS_URL = "redis://default:uSJmhvtfgYyWUMrFrSGrcuUAVXQfkpvD@metro.proxy.rlwy.net:54279"
 # IMPORTANT: Set these environment variables in Railway Dashboard:
 # API_SECRET = "your_api_secret_key" # Must match bot service API_SECRET
 # NextAuth Configuration - SET THESE IN RAILWAY DASHBOARD


### PR DESCRIPTION
Set `REDIS_URL` in `railway.toml` for both services to use the Railway public Redis proxy and resolve DNS connection errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a43354d-b5d1-40da-8ef8-2d456152a457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7a43354d-b5d1-40da-8ef8-2d456152a457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

