### PR TITLE
Check and enhance bot stats command

### DIFF
--- a/packages/bot/src/commands/stats.ts
+++ b/packages/bot/src/commands/stats.ts
@@ -54,7 +54,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
         const member = await guild.members.fetch(interaction.user.id);
         
         // Check if user has permission to view stats
-        const hasPermission = permissionUtil.isSupportStaff(member) ||
+        const hasPermission = await permissionUtil.isSupportStaff(member) ||
                               permissionUtil.hasAdminPermissions(member);
 
         if (!hasPermission) {
@@ -273,13 +273,13 @@ async function handleUserStats(
 
         if (!userStats) {
             await interaction.editReply({
-                content: `❌ No ticket activity found for ${targetUser.displayName}.`
+                content: `❌ No ticket activity found for ${targetUser.username}.`
             });
             return;
         }
 
         const embed = new EmbedBuilder()
-            .setTitle(`📊 User Statistics - ${targetUser.displayName}`)
+            .setTitle(`📊 User Statistics - ${targetUser.username}`)
             .setThumbnail(targetUser.displayAvatarURL())
             .setColor(0x0099ff)
             .setTimestamp()

--- a/packages/bot/src/database/TicketDAO.ts
+++ b/packages/bot/src/database/TicketDAO.ts
@@ -403,6 +403,25 @@ export class TicketDAO {
         }
     }
 
+	/**
+	 * Get tickets closed within a date range (based on closed_at)
+	 */
+	public async getTicketsClosedByDateRange(guildId: string, startDate: Date, endDate: Date): Promise<Ticket[]> {
+		try {
+			const result = await this.dbManager.query(`
+				SELECT * FROM tickets 
+				WHERE guild_id = $1 AND status = 'closed' AND closed_at IS NOT NULL
+				AND closed_at >= $2 AND closed_at < $3
+				ORDER BY closed_at DESC
+			`, [guildId, startDate.toISOString(), endDate.toISOString()]);
+
+			return result.rows.map((row: TicketRow) => this.mapRowToTicket(row));
+		} catch (error: unknown) {
+			console.error('Error fetching tickets closed by date range:', error);
+			return [];
+		}
+	}
+
     /**
      * Assign a ticket to a user
      */

--- a/packages/bot/src/utils/StatsHandler.ts
+++ b/packages/bot/src/utils/StatsHandler.ts
@@ -480,15 +480,15 @@ export class StatsHandler {
         averageResolutionHours: number;
     }> {
         const overview = await this.getTicketOverview(guildId);
-        
-        // Get tickets closed today
+
+        // Count tickets closed today using closed_at window
         const today = new Date();
         today.setHours(0, 0, 0, 0);
         const tomorrow = new Date(today);
         tomorrow.setDate(tomorrow.getDate() + 1);
-        
-        const todayTickets = await this.ticketDAO.getTicketsByDateRange(guildId, today, tomorrow);
-        const closedToday = todayTickets.filter(t => t.status === 'closed').length;
+
+        const closedTodayTickets = await this.ticketDAO.getTicketsClosedByDateRange(guildId, today, tomorrow);
+        const closedToday = closedTodayTickets.length;
 
         return {
             totalTickets: overview.total,


### PR DESCRIPTION
Awaits `isSupportStaff` check, uses `username` for reliability, and adds `getTicketsClosedByDateRange` to accurately count tickets closed today.

The `permissionUtil.isSupportStaff` function is asynchronous and needs to be awaited for the permission check to function correctly. `targetUser.displayName` can be `undefined` in certain contexts (like DMs), so `targetUser.username` is used for consistent display. The previous method for counting "closed today" was incorrect as it filtered tickets created today by status; the new `getTicketsClosedByDateRange` method correctly queries tickets based on their `closed_at` timestamp.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ab19e44-bd39-45ec-a69b-64e0b72974ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ab19e44-bd39-45ec-a69b-64e0b72974ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

