### PR TITLE
Check and enhance bot stats command

### DIFF
--- a/packages/bot/src/commands/stats.ts
+++ b/packages/bot/src/commands/stats.ts
@@ -41,6 +41,11 @@ export const data = new SlashCommandBuilder()
                     .setRequired(true)
             )
     )
+    .addSubcommand(subcommand =>
+        subcommand
+            .setName('realtime')
+            .setDescription('View real-time ticket statistics')
+    )
     .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels);
 
 export async function execute(interaction: ChatInputCommandInteraction) {
@@ -79,6 +84,9 @@ export async function execute(interaction: ChatInputCommandInteraction) {
                 break;
             case 'user':
                 await handleUserStats(interaction, statsHandler);
+                break;
+            case 'realtime':
+                await handleRealtimeStats(interaction, statsHandler);
                 break;
             default:
                 await interaction.reply({
@@ -119,7 +127,17 @@ async function handleOverview(
     await interaction.deferReply();
 
     try {
-        const quickStats = await statsHandler.getQuickStats(interaction.guildId!);
+        const [quickStats, trendingStats] = await Promise.all([
+            statsHandler.getQuickStats(interaction.guildId!),
+            statsHandler.getTrendingStats(interaction.guildId!, 7)
+        ]);
+        
+        // Format trend indicators
+        const formatTrend = (trend: number) => {
+            if (trend > 0) return `📈 +${trend}%`;
+            if (trend < 0) return `📉 ${trend}%`;
+            return `➡️ 0%`;
+        };
         
         const embed = new EmbedBuilder()
             .setTitle('📊 Quick Statistics Overview')
@@ -158,6 +176,15 @@ async function handleOverview(
                     value: quickStats.openTickets === 0 ? '🟢 All Clear' : 
                            quickStats.openTickets < 5 ? '🟡 Normal' : '🔴 High Load',
                     inline: true
+                },
+                {
+                    name: '📊 7-Day Trends',
+                    value: [
+                        `**Tickets Created:** ${formatTrend(trendingStats.ticketsCreatedTrend)}`,
+                        `**Tickets Closed:** ${formatTrend(trendingStats.ticketsClosedTrend)}`,
+                        `**Resolution Time:** ${formatTrend(trendingStats.resolutionTimeTrend)}`
+                    ].join('\n'),
+                    inline: false
                 }
             )
             .setFooter({ text: 'Use /stats detailed for more comprehensive statistics' });
@@ -342,6 +369,68 @@ async function handleUserStats(
         console.error('Error in user stats:', error);
         await interaction.editReply({
             content: '❌ Failed to retrieve user statistics.'
+        });
+    }
+}
+
+/**
+ * Handle realtime stats subcommand
+ */
+async function handleRealtimeStats(
+    interaction: ChatInputCommandInteraction,
+    statsHandler: StatsHandler
+) {
+    await interaction.deferReply();
+
+    try {
+        const quickStats = await statsHandler.getQuickStats(interaction.guildId!);
+        
+        // Get current time for real-time context
+        const now = new Date();
+        const currentHour = now.getHours();
+        const currentDay = now.toLocaleDateString('en-US', { weekday: 'long' });
+        
+        const embed = new EmbedBuilder()
+            .setTitle('⚡ Real-Time Statistics')
+            .setColor(0x00ff00)
+            .setTimestamp()
+            .addFields(
+                {
+                    name: '🎫 Current Status',
+                    value: [
+                        `**Open Tickets:** ${quickStats.openTickets}`,
+                        `**Closed Today:** ${quickStats.closedToday}`,
+                        `**Total Tickets:** ${quickStats.totalTickets}`
+                    ].join('\n'),
+                    inline: true
+                },
+                {
+                    name: '⏱️ Performance',
+                    value: [
+                        `**Avg Resolution:** ${quickStats.averageResolutionHours}h`,
+                        `**Current Hour:** ${currentHour}:00`,
+                        `**Current Day:** ${currentDay}`
+                    ].join('\n'),
+                    inline: true
+                },
+                {
+                    name: '📊 Status Indicator',
+                    value: quickStats.openTickets === 0 ? '🟢 All Clear - No open tickets' : 
+                           quickStats.openTickets < 5 ? '🟡 Normal Load' : 
+                           quickStats.openTickets < 10 ? '🟠 High Load' : '🔴 Critical Load',
+                    inline: true
+                }
+            )
+            .setFooter({ 
+                text: 'Real-time data • Use /stats detailed for comprehensive analytics' 
+            });
+
+        await interaction.editReply({ embeds: [embed] });
+
+    } catch (error) {
+        console.error('Error in realtime stats:', error);
+        await interaction.editReply({
+            content: '❌ Failed to retrieve real-time statistics.'
         });
     }
 }


### PR DESCRIPTION
Optimize `getGuildStatistics` to fetch tickets once and add `/stats realtime` and trending overview statistics.

The `getGuildStatistics` method previously fetched all guild tickets five times, causing significant performance overhead. This PR refactors it to fetch tickets only once and reuse the data for all subsequent calculations. Additionally, new real-time and trending statistics were added to enhance the command's utility and provide more actionable insights, addressing the user's request for enhancements.

---
<a href="https://cursor.com/background-agent?bcId=bc-a707de5c-4b39-490d-9a56-acbf2721dd3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a707de5c-4b39-490d-9a56-acbf2721dd3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

